### PR TITLE
Add script to populate song collection in database

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,5 @@ To run this on your local machine:
 ```
 4. Start `mongod` which must run separately
 5. From the glorifycc directory, run `gulp` to start up the server
-6. Go to http://localhost:8000 to test the webapp
+6. Run `node bin/dev-setup` to populate your local database
+7. Go to http://localhost:8000 to test the webapp

--- a/app.js
+++ b/app.js
@@ -31,13 +31,12 @@ var song = require('./routes/song')
 var language = require('./routes/language')
 
 
-var MongoURI = process.env.MONGOURI || 'mongodb://localhost/song-database';
-mongoose.Promise = global.Promise;
-mongoose.connect(MongoURI, function(err, database) {
+var mongoConfig = require('./lib/mongoConfig');
+mongoose.connect(mongoConfig.uri, function(err, database) {
     if (err) {
-        console.log('Error connecting to: ' + MongoURI + '. ' + err);
+        console.log('Error connecting to: ' + mongoConfig.uri + '. ' + err);
     } else {
-        console.log('MongoDB connected successfully to ' + MongoURI);
+        console.log('MongoDB connected successfully to ' + mongoConfig.uri);
     }
 });
 require('./lib/passport');

--- a/bin/dev-setup
+++ b/bin/dev-setup
@@ -23,7 +23,6 @@ var sampleSong = new Song({
     'Will be forever mine.']
   ],
   source: null,
-  oriSong: null,
   timeAdded: new Date()
 });
 
@@ -46,7 +45,6 @@ var translatedSong = new Song({
     'verso :( ]']
   ],
   source: null, // will be changed
-  oriSong: 'Amazing Grace',
   timeAdded: new Date()
 });
 
@@ -56,7 +54,7 @@ sampleSong.save().then(
   function(song) {
     console.log('Saved sample song "' + song.title + '" with id ' + song.id);
     translatedSong.source = song.id;
-    return translatedSong.save(translatedSong)
+    return translatedSong.save()
   }, function(err) {
     console.log("Unable to store sample song. Reason:");
     console.log(err);

--- a/bin/dev-setup
+++ b/bin/dev-setup
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+var mongoose = require('mongoose');
+var mongoConfig = require('../lib/mongoConfig');
+var Song = require('../models/song');
+
+var sampleSong = new Song({
+  title: 'Amazing Grace',
+  author: 'John Newton and Virginia Harmony',
+  year: '1779',
+  lang: 'English',
+  translator: null,
+  contributor: 'dev-setup-script',
+  copyright: 'Public',
+  lyric: [
+    ['Amazing grace! how sweet the sound,',
+    'That saved a wretch like me!',
+    'I once was lost, but now am found;',
+    'Was blind, but now I see.'],
+    ['The earth shall soon dissolve like snow;',
+    'The sun forbear to shine;',
+    'But God, who called me here below,',
+    'Will be forever mine.']
+  ],
+  source: null,
+  oriSong: null,
+  timeAdded: new Date()
+});
+
+var translatedSong = new Song({
+  title: 'Sublime gracia del Señor',
+  author: 'John Newton y Virginia Harmony',
+  year: '1779',
+  lang: 'Spanish',
+  translator: 'algún desarrollador de software probablamente',
+  contributor: 'dev-setup-script',
+  copyright: 'Public',
+  lyric: [
+    ['Sublime gracia del Señor',
+    'Que a mi pecador salvó',
+    'Fui ciego mas hoy miro yo',
+    'Perdido y el me amó.'],
+    ['[ No tenemos',
+    'una traducción',
+    'para este',
+    'verso :( ]']
+  ],
+  source: null, // will be changed
+  oriSong: 'Amazing Grace',
+  timeAdded: new Date()
+});
+
+mongoose.connect(mongoConfig.uri);
+
+sampleSong.save().then(
+  function(song) {
+    console.log('Saved sample song "' + song.title + '" with id ' + song.id);
+    translatedSong.source = song.id;
+    return translatedSong.save(translatedSong)
+  }, function(err) {
+    console.log("Unable to store sample song. Reason:");
+    console.log(err);
+    throw "Unable to store sample song";
+  }
+).then(
+  function(song) {
+    console.log('Saved translated song "' + song.title + '" with id ' + song.id);
+  }, function(err) {
+    console.log("Unable to store translated song. Reason:");
+    console.log(err); // either db failure or "Unable to store sample song"
+  }
+).then( // this promise is always fulfilled b/c errors are caught and logged above
+  function() {
+    console.log('Closing DB connection');
+    mongoose.connection.close();
+  }
+);

--- a/lib/mongoConfig.js
+++ b/lib/mongoConfig.js
@@ -1,0 +1,6 @@
+var mongoose = require('mongoose');
+
+var MongoURI = process.env.MONGOURI || 'mongodb://localhost/song-database';
+mongoose.Promise = global.Promise;
+
+module.exports = {uri: MongoURI};


### PR DESCRIPTION
(For running on dev desktops)

I also moved the MongoDB URI to a separate file.  This file is now referenced by app.js and my script.

## Testing

cleared database song collection and ran `node bin/dev-setup` - output:
```
Saved sample song "Amazing Grace" with id 582e227b5d45682508aa450e
Saved translated song "Sublime gracia del Señor" with id 582e227b5d45682508aa450f
Closing DB connection
```

And verified the songs in the DB and the UI.

To test the error path I replaced the line `sampleSong.save().then(` with
```javascript
sampleSong.save().then(
  function(song) {
    throw song.author;
  }
).then
```

When I ran the script, the output was
```
Unable to store sample song. Reason:
John Newton and Virginia Harmony
Unable to store translated song. Reason:
Unable to store sample song
Closing DB connection
```